### PR TITLE
Fixed a bug when using scratch-n-see on iPhone 6S

### DIFF
--- a/Scratch & See/Classes/MDScratchImageView/MDScratchImageView.mm
+++ b/Scratch & See/Classes/MDScratchImageView/MDScratchImageView.mm
@@ -284,7 +284,14 @@ inline CGPoint scalePoint(CGPoint point, CGSize previousSize, CGSize currentSize
 	
 	// iterate on points between begin and end
 	CGPoint i = begin;
-	while(i.x <= end.x && i.y <= end.y){
+    /*
+     * WAS `while(i.x <= end.x && i.y <= end.y)`
+     * changed (`=` removed) to the code below because of an issue on iPhone 6S
+     * On iPhone 6S it happens very often that because of the screen's
+     * preciseness, begin.x equals to end.x and same for y which causes
+     * unsatisfied while condition resulting a memory error
+     */
+	while(i.x < end.x && i.y < end.y){
 		(*fillTileFunc)(self,@selector(fillTileWithPoint:),i);
 		i.x += incrementerForx;
 		i.y += incrementerFory;


### PR DESCRIPTION
In implementation file MDScratchImageView.mm

method name: - fillTileWithTwoPoints:begin:end:
`while (i.x <= end.x && i.y <= end.y)` is not satisfied on iPhone 6S - apparently due to new hardware preciseness, a touch with the same begin and end points is created and causes the above.
